### PR TITLE
Copy the test data to the output test directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ project(hexit)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Uncomment to check the source and binary directories
+#message(STATUS "CMAKE_BINARY_DIR: ${CMAKE_BINARY_DIR}")
+#message(STATUS "CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
+
 # Taken from https://google.github.io/googletest/quickstart-cmake.html
 include(FetchContent)
 FetchContent_Declare(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,9 @@
 enable_testing()
 
+# Copy the file that is used in the unit test cases
+file(COPY ${CMAKE_SOURCE_DIR}/hex_mode.png DESTINATION ${CMAKE_BINARY_DIR}/test)
+file(RENAME ${CMAKE_BINARY_DIR}/test/hex_mode.png ${CMAKE_BINARY_DIR}/test/data.test)
+
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "&{CMAKE_BINARY_DIR}")
 add_executable(DataBufferTest)
 

--- a/test/DataBufferTest.cc
+++ b/test/DataBufferTest.cc
@@ -10,7 +10,7 @@ namespace fs = std::filesystem;
 
 namespace
 {
-const std::string file_name("../hex_mode.png");
+const std::string file_name("data.test");
 }
 
 TEST(DataBufferTest, FileData)


### PR DESCRIPTION
CMake will now copy the binary file that is used as data from the unit tests(hex_mode.png)
and store it under ${CMAKE_BINARY_DIR}/test as data.test