### PR TITLE
Cursor fix

### DIFF
--- a/src/ChunkCache.cc
+++ b/src/ChunkCache.cc
@@ -32,7 +32,8 @@ bool ChunkCache::open(const fs::path& path, bool immutable)
 
 bool ChunkCache::load_chunk(std::uint32_t chunk_id)
 {
-    m_handler.seek(chunk_id * capacity);
+    if (!m_handler.seek(chunk_id * capacity))
+        return false;
 
     std::uint32_t bytes_to_read = capacity;
     if (chunk_id == (m_total_chunks - 1) && m_handler.size() % capacity)
@@ -53,8 +54,9 @@ bool ChunkCache::save_chunk(const DataChunk& chunk)
 {
     if (m_immutable)
         return false;
+    if (!m_handler.seek(chunk.m_id * ChunkCache::capacity))
+        return false;
 
-    m_handler.seek(chunk.m_id * ChunkCache::capacity);
     return m_handler.write(chunk.m_data, chunk.m_count);
 }
 

--- a/src/FileHandler.cc
+++ b/src/FileHandler.cc
@@ -49,12 +49,12 @@ bool FileHandler::write(const std::uint8_t* i_buffer, std::size_t buffer_size)
         m_stream.write(reinterpret_cast<const char*>(i_buffer), buffer_size));
 }
 
-void FileHandler::seek(std::uint32_t offset)
+bool FileHandler::seek(std::uint32_t offset)
 {
     if (!m_stream.is_open())
-        return;
+        return false;
 
-    m_stream.seekg(offset);
+    return static_cast<bool>(m_stream.seekg(offset));
 }
 
 const fs::path& FileHandler::name() const

--- a/src/FileHandler.h
+++ b/src/FileHandler.h
@@ -19,7 +19,7 @@ public:
 
     bool write(const std::uint8_t* i_buffer, std::size_t buffer_size) override;
 
-    void seek(std::uint32_t offset) override;
+    bool seek(std::uint32_t offset) override;
 
     const fs::path& name() const override;
 

--- a/src/IOHandler.h
+++ b/src/IOHandler.h
@@ -19,7 +19,7 @@ public:
 
     virtual bool write(const std::uint8_t* i_buffer, std::size_t buffer_size) = 0;
 
-    virtual void seek(std::uint32_t offset) = 0;
+    virtual bool seek(std::uint32_t offset) = 0;
 
     virtual const fs::path& name() const = 0;
 

--- a/src/StdInHandler.cc
+++ b/src/StdInHandler.cc
@@ -48,12 +48,13 @@ bool StdInHandler::write(const std::uint8_t* i_buffer, std::size_t buffer_size)
     return true;
 }
 
-void StdInHandler::seek(std::uint32_t offset)
+bool StdInHandler::seek(std::uint32_t offset)
 {
     if (m_data.empty() || offset >= m_size)
-        return;
+        return false;
 
     m_offset = offset;
+    return true;
 }
 
 const fs::path& StdInHandler::name() const

--- a/src/StdInHandler.h
+++ b/src/StdInHandler.h
@@ -19,7 +19,7 @@ public:
 
     bool write(const std::uint8_t* i_buffer, std::size_t buffer_size) override;
 
-    void seek(std::uint32_t offset) override;
+    bool seek(std::uint32_t offset) override;
 
     const fs::path& name() const override;
 

--- a/src/TerminalWindow.cc
+++ b/src/TerminalWindow.cc
@@ -55,7 +55,7 @@ TerminalWindow::TerminalWindow(WINDOW* win, DataBuffer& data, std::uint32_t star
         m_scroller.m_last_line = m_visible_lines;
     }
 
-    std::sprintf(m_left_padding_format, "%%0%dX  ", LEFT_PADDING_CHARS);
+    std::sprintf(m_left_padding_format, "%%0%dX", LEFT_PADDING_CHARS);
     m_input_buffer.reserve(LEFT_PADDING_CHARS);
 }
 
@@ -76,6 +76,7 @@ void TerminalWindow::draw_line(std::uint32_t line)
 
     // Draw the byte index.
     mvwprintw(m_screen, line + 1, 1, m_left_padding_format, byte_index);
+    mvwprintw(m_screen, line + 1, 1 + LEFT_PADDING_CHARS, "  ");
     // Draw the HEX part.
     for (std::uint32_t i = 0; i < BYTES_PER_LINE; ++i, col += 3, byte_index++)
     {
@@ -84,6 +85,7 @@ void TerminalWindow::draw_line(std::uint32_t line)
             bool is_dirty     = m_data.is_dirty(byte_index);
             char hexDigits[3] = { 0 };
             std::sprintf(hexDigits, "%02X", m_data[byte_index]);
+
             if (byte_index == m_current_byte)
             {
                 if (m_mode == Mode::HEX)
@@ -179,6 +181,10 @@ void TerminalWindow::update_screen()
         if (m_cy < m_visible_lines)
             draw_line(m_cy);
     }
+
+    // Draw the current byte index
+    if (m_prompt == Prompt::NONE)
+        mvwprintw(m_screen, LINES - 1, 1, m_left_padding_format, m_current_byte);
 }
 
 void TerminalWindow::erase() const

--- a/src/TerminalWindow.h
+++ b/src/TerminalWindow.h
@@ -85,7 +85,7 @@ private:
     Mode          m_mode;
     Prompt        m_prompt;
     WINDOW*       m_screen;
-    std::uint32_t m_current_byte, m_current_byte_offset;
+    std::uint32_t m_byte, m_byte_offset;
     char          m_left_padding_format[sizeof("%%0%dX  ")];
     bool          m_quit;
     std::string   m_input_buffer;

--- a/src/hexit.cc
+++ b/src/hexit.cc
@@ -29,6 +29,7 @@ inline void init_ncurses()
     initscr();
     raw();
     noecho();
+    curs_set(0); // invisible cursor
     start_color();
     init_pair(1, COLOR_GREEN, COLOR_BLACK);
     keypad(stdscr, true);

--- a/test/DataBufferTest.cc
+++ b/test/DataBufferTest.cc
@@ -62,9 +62,10 @@ public:
         return true;
     }
 
-    void seek(std::uint32_t offset) override
+    bool seek(std::uint32_t offset) override
     {
         m_id = offset / ChunkCache::capacity;
+        return true;
     }
 
     const fs::path& name() const override


### PR DESCRIPTION
Under WSL2, the cursor was not visible.

This PR, fixes that as well as adds some more minor changes such as:

- Display the current byte number on the bottom left of the screen.
- Display modified bytes on both hex and ascii parts at the same time.